### PR TITLE
Subchapters (#36)

### DIFF
--- a/scripts/myMangaDex.js
+++ b/scripts/myMangaDex.js
@@ -1210,8 +1210,9 @@ class MyMangaDex {
 	// END HELP / START PAGE
 
 	async chapterListPage() {
-		if (!this.options.highlightChapters && !this.options.hideLowerChapters &&
-			!this.options.showTooltips && !this.options.highlightNextChapter) {
+		if (!this.options.highlightChapters &&
+			!this.options.hideLowerChapters && !this.options.hideHigherChapters && !this.options.hideLastRead &&
+			!this.options.showTooltips) {
 			return;
 		} // Abort early if useless - no highlight, no hiding and no thumbnails
 		let groups = this.getChapterListGroups();

--- a/scripts/myMangaDex.js
+++ b/scripts/myMangaDex.js
@@ -516,7 +516,7 @@ class MyMangaDex {
 		}
 
 		// Get the name of each "chapters" in the list - ignore first line
-		let hasChapterZero = false;
+		let firstChapter = undefined;
 		let foundNext = false;
 		let markFullChapter = undefined;
 		for (let i = 0; i < chaptersList.length - 1; i++) {
@@ -524,8 +524,8 @@ class MyMangaDex {
 			let chapterVolume = this.getVolumeChapterFromNode(element.firstElementChild.firstElementChild);
 			chapterVolume.chapterFloored = Math.floor(chapterVolume.chapter);
 
-			if (chapterVolume.chapterFloored == 0) {
-				hasChapterZero = true;
+			if (firstChapter === undefined) {
+				firstChapter = chapterVolume.chapter;
 			}
 			// if is current chapter and subchapter matches, proceed as normal
 			if (markFullChapter === undefined && chapterVolume.chapter == this.manga.lastMangaDexChapter) {
@@ -537,7 +537,7 @@ class MyMangaDex {
 				markFullChapter = true;
 			}
 			// TODO: Also check volume if it saved
-			if (((this.manga.lastMyAnimeListChapter == -1 || this.manga.lastMangaDexChapter == -1) && chapterVolume.chapterFloored == (hasChapterZero ? 0 : 1)) ||
+			if (((this.manga.lastMyAnimeListChapter == -1 || this.manga.lastMangaDexChapter == -1) && chapterVolume.chapter == firstChapter) ||
 				((this.manga.lastMangaDexChapter == -1 || markFullChapter) && this.manga.lastMyAnimeListChapter + 1 == chapterVolume.chapterFloored) ||
 				(this.manga.lastMangaDexChapter != -1 && parseFloat(chapterVolume.chapter) > this.manga.lastMangaDexChapter &&
 					(foundNext === false || foundNext === chapterVolume.chapter) && !markFullChapter)) {

--- a/scripts/myMangaDex.js
+++ b/scripts/myMangaDex.js
@@ -167,7 +167,8 @@ class MyMangaDex {
 					//realChapter == this.manga.lastMyAnimeListChapter ||
 					realChapter == this.manga.lastMyAnimeListChapter + 1); // ||
 						//(!this.options.saveOnlyHigher && realChapter == this.manga.lastMyAnimeListChapter - 1));*/
-				let maybeNext = isHigherDex && this.manga.currentChapter.chapter <= Math.floor(this.manga.lastMangaDexChapter)+1;
+				let maybeNext = isHigherDex && realChapter <= Math.floor(this.manga.lastMangaDexChapter)+1;
+				console.log(this.manga.currentChapter, this.manga.lastMangaDexChapter, isHigherDex, maybeNext);
 				if (!force && usePepper && this.options.saveOnlyNext && this.manga.lastMyAnimeListChapter > 0 && !maybeNext) {
 					if (this.options.confirmChapter) {
 						SimpleNotification.info({

--- a/scripts/myMangaDex.js
+++ b/scripts/myMangaDex.js
@@ -534,9 +534,10 @@ class MyMangaDex {
 			// TODO: Also check volume if it saved
 			if ((!hasChapterZero && this.manga.lastMyAnimeListChapter == -1 && chapterVolume.chapterFloored == 1) ||
 				((this.manga.lastMangaDexChapter == -1 || markFullChapter) && this.manga.lastMyAnimeListChapter + 1 == chapterVolume.chapterFloored) ||
-				(parseFloat(chapterVolume.chapter) > this.manga.lastMangaDexChapter && !foundNext && !markFullChapter)) {
+				(parseFloat(chapterVolume.chapter) > this.manga.lastMangaDexChapter &&
+					(foundNext === false || foundNext === chapterVolume.chapter) && !markFullChapter)) {
 				element.style.backgroundColor = this.options.nextChapterColor;
-				foundNext = true;
+				foundNext = parseFloat(chapterVolume.chapter);
 			} else if (this.manga.lastMyAnimeListChapter == chapterVolume.chapterFloored &&
 				(this.manga.lastMangaDexChapter == -1 || chapterVolume.chapter == this.manga.lastMangaDexChapter)) {
 				element.style.backgroundColor = this.options.lastReadColor;

--- a/scripts/myMangaDex.js
+++ b/scripts/myMangaDex.js
@@ -138,7 +138,7 @@ class MyMangaDex {
 				let realChapter = Math.floor(this.manga.currentChapter.chapter);
 				let isHigher = (realChapter < 0 || realChapter > this.manga.lastMyAnimeListChapter);
 				let isHigherDex = (isHigher || (this.manga.lastMangaDexChapter != -1 && this.manga.currentChapter.chapter > this.manga.lastMangaDexChapter));
-				if (!force && usePepper && !isHigherDex && (this.options.saveOnlyHigher || this.manga.currentChapter.chapter == this.manga.lastMangaDexChapter)) {
+				if (!force && usePepper && !isHigherDex && this.options.saveOnlyHigher) {
 					if (this.options.confirmChapter) {
 						SimpleNotification.info({
 							title: "Not updated",
@@ -163,11 +163,12 @@ class MyMangaDex {
 					return;
 				}
 
-				let isNext = (realChapter < 0 ||
+				/*let isNext = (realChapter < 0 ||
 					//realChapter == this.manga.lastMyAnimeListChapter ||
 					realChapter == this.manga.lastMyAnimeListChapter + 1); // ||
-						//(!this.options.saveOnlyHigher && realChapter == this.manga.lastMyAnimeListChapter - 1));
-				if (!force && usePepper && this.options.saveOnlyNext && this.manga.lastMyAnimeListChapter > 0 && !isNext) {
+						//(!this.options.saveOnlyHigher && realChapter == this.manga.lastMyAnimeListChapter - 1));*/
+				let maybeNext = isHigherDex && this.manga.currentChapter.chapter <= Math.floor(this.manga.lastMangaDexChapter)+1;
+				if (!force && usePepper && this.options.saveOnlyNext && this.manga.lastMyAnimeListChapter > 0 && !maybeNext) {
 					if (this.options.confirmChapter) {
 						SimpleNotification.info({
 							title: "Not updated",


### PR DESCRIPTION
Reader updates if higher subchapter, request to MAL only if `realChapter != lastMyAnimeListChapter`
On title page simply select the one after the current chapter as next (and all with same chapter value)
When no chapter corresponding to `lastMangaDexChapter` is found, mark all subchapters as current one (assume was synced from MAL)
On chapter list move information collection to front and calculate next chapter

Did not detect any bugs, but might need more testing
Closes #36 