### PR TITLE
Fetch on follows, Add/remove chapters

### DIFF
--- a/build.js
+++ b/build.js
@@ -81,7 +81,8 @@ let manifest = {
 
 	content_scripts: [{
 		matches: [
-			'https://*.mangadex.org/follows/?',
+			'https://*.mangadex.org/follows',
+			'https://*.mangadex.org/follows/',
 			'https://*.mangadex.org/follows/manga/0/0/*',
 			'https://*.mangadex.org/follows/chapters/*',
 			'https://*.mangadex.org/manga*',

--- a/build.js
+++ b/build.js
@@ -169,6 +169,7 @@ let dev = false;
 if (args.indexOf('-dev') >= 0) {
 	dev = true;
 	noMinify = true;
+	debug = true;
 }
 
 console.log(`Building for ${browser}`);

--- a/build.js
+++ b/build.js
@@ -81,7 +81,7 @@ let manifest = {
 
 	content_scripts: [{
 		matches: [
-			'https://*.mangadex.org/follows',
+			'https://*.mangadex.org/follows/?',
 			'https://*.mangadex.org/follows/manga/0/0/*',
 			'https://*.mangadex.org/follows/chapters/*',
 			'https://*.mangadex.org/manga*',

--- a/css/mymangadex.css
+++ b/css/mymangadex.css
@@ -1,10 +1,25 @@
 /* Animation */
 @keyframes pulse {
-    0% { box-shadow: 0px 0px 4px 1px #78C5D5; }
-    25% { box-shadow: 0px 0px 4px 1px #79C268; }
-    50% { box-shadow: 0px 0px 4px 1px #F5D63D; }
-    75% { box-shadow: 0px 0px 4px 1px #E868A1; }
-    100% { box-shadow: 0px 0px 4px 1px #BF63A6; }
+	0% {
+		background-color: rgba(120, 197, 213, 0.5);
+		box-shadow: 0px 0px 4px 1px #78C5D5;
+	}
+    25% {
+		background-color: rgba(121, 194, 104, 0.5);
+		box-shadow: 0px 0px 4px 1px #79C268;
+	}
+    50% {
+		background-color: rgba(245, 214, 61, 0.5);
+		box-shadow: 0px 0px 4px 1px #F5D63D;
+	}
+    75% {
+		background-color: rgba(232, 104, 162, 0.5);
+		box-shadow: 0px 0px 4px 1px #E868A1;
+	}
+    100% {
+		background-color: rgba(191, 99, 166, 0.5);
+		box-shadow: 0px 0px 4px 1px #BF63A6;
+	}
 }
 
 /* Tooltips */

--- a/css/mymangadex.css
+++ b/css/mymangadex.css
@@ -1,3 +1,12 @@
+/* Animation */
+@keyframes pulse {
+    0% { box-shadow: 0px 0px 4px 1px #78C5D5; }
+    25% { box-shadow: 0px 0px 4px 1px #79C268; }
+    50% { box-shadow: 0px 0px 4px 1px #F5D63D; }
+    75% { box-shadow: 0px 0px 4px 1px #E868A1; }
+    100% { box-shadow: 0px 0px 4px 1px #BF63A6; }
+}
+
 /* Tooltips */
 .mmd-tooltip {
     display: block;
@@ -43,10 +52,11 @@
 }
 .is-loading {
     animation-name: pulse;
-    animation-duration: 2s;
+    animation-duration: 4s;
     animation-timing-function: ease-in-out;
     animation-direction: alternate;
-    animation-iteration-count: infinite;
+	animation-iteration-count: infinite;
+	color: white;
 }
 .has-transition {
     transition: all 0.2s cubic-bezier(0.455, 0.03, 0.515, 0.955);

--- a/css/mymangadex.css
+++ b/css/mymangadex.css
@@ -56,7 +56,6 @@
     animation-timing-function: ease-in-out;
     animation-direction: alternate;
 	animation-iteration-count: infinite;
-	color: white;
 }
 .has-transition {
     transition: all 0.2s cubic-bezier(0.455, 0.03, 0.515, 0.955);

--- a/options.html
+++ b/options.html
@@ -114,6 +114,18 @@
                     </div>
                 </div>
                 <div class="form-group text-container p-2">
+                    <label class="font-weight-bold">Update on Follows page <a data-default="updateOnFollows" class="btn btn-sm btn-secondary"><i class="fas fa-trash"></i><span class="d-none d-xl-inline"> Restore default</span></a></label>
+                    <p class="d-none d-xl-block">Automatically check if new chapters have already been read (on MyAnimeList). Only checks the first 7 with unread higher chapters.</p>
+                    <div data-option="updateOnFollows" data-type="checkbox" class="col px-0 my-auto input-group">
+                        <div class="input-group-prepend">
+                            <button type="button" class="btn btn-success input-prepend col px-2">Enabled</button>
+                        </div>
+                        <div class="input-group-append">
+                            <button type="button" class="btn btn-secondary input-append col px-2 active">Disabled</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group text-container p-2">
                     <label class="font-weight-bold">Show notifications <a data-default="showNotifications" class="btn btn-sm btn-secondary"><i class="fas fa-trash"></i><span class="d-none d-xl-inline"> Restore default</span></a></label>
                     <p class="d-none d-xl-block">Display notifications in the bottom left corner. Do not disable error notifications, see below.</p>
                     <div data-option="showNotifications" data-type="checkbox" class="col px-0 my-auto input-group">

--- a/scripts/defaultOptions.js
+++ b/scripts/defaultOptions.js
@@ -42,6 +42,7 @@ let defaultOptions = {
 	updateOnlyInList: false,
 	historySize: 100,
 	updateMDList: false,
+	updateOnFollows: true,
 	showTooltips: true,
 	showFullCover: false,
 	coverMaxHeight: 80,

--- a/scripts/defaultOptions.js
+++ b/scripts/defaultOptions.js
@@ -42,7 +42,7 @@ let defaultOptions = {
 	updateOnlyInList: false,
 	historySize: 100,
 	updateMDList: false,
-	updateOnFollows: true,
+	updateOnFollows: false,
 	showTooltips: true,
 	showFullCover: false,
 	coverMaxHeight: 80,

--- a/scripts/myMangaDex.js
+++ b/scripts/myMangaDex.js
@@ -1375,6 +1375,7 @@ class MyMangaDex {
 								lastMangaDexChapter: titleInformations[group.titleId].last,
 								chapters: titleInformations[group.titleId].chapters || []
 							});
+							titleInformations[group.titleId].next = Infinity;
 							titleInformations[group.titleId].getsUpdated = true;
 							break; // no need to check this title any more
 						}

--- a/scripts/myMangaDex.js
+++ b/scripts/myMangaDex.js
@@ -72,7 +72,7 @@ class MyMangaDex {
 		}
 
 		// clean up existing nodes
-		const oldDomNodes = document.querySelectorAll("body > .gn-wrapper, #mmd-tooltip");
+		const oldDomNodes = document.querySelectorAll("body > .gn-wrapper, #mmd-tooltip, .nav-item.mmdNav");
 		oldDomNodes.forEach(node => node.remove());
 		const oldToolTips = document.querySelectorAll(".row[data-loaded=\"true\"]");
 		oldToolTips.forEach(node => node.removeAttribute("data-loaded"));
@@ -1262,9 +1262,12 @@ class MyMangaDex {
 		let chapter = +dataNode.dataset.chapter;
 
 		if (this.pageType != "title") {
-			this.manga = { mangaDexId: dataNode.dataset["manga-id"] };
+			this.manga = { mangaDexId: dataNode.dataset.mangaId };
 			await this.getTitleInfos();
+
+			if (this.manga.myAnimeListId) await this.fetchMyAnimeList();
 		}
+		this.manga.currentChapter = this.manga.currentChapter || { chapter: -1, volume: 0 };
 		if (markUnread) {
 			let updateLast = this.manga.lastMangaDexChapter == chapter;
 			this.manga.chapters = this.manga.chapters.filter(chap => {
@@ -1284,11 +1287,10 @@ class MyMangaDex {
 			}
 		}
 
-		if (Math.floor(this.manga.lastMangaDexChapter) != this.manga.lastMyAnimeListChapter) {
-			this.manga.lastMyAnimeListChapter = Math.floor(this.manga.lastMangaDexChapter);
+		if (this.manga.myAnimeListId && (!this.manga.lastMyAnimeListChapter || Math.floor(this.manga.lastMangaDexChapter) != this.manga.lastMyAnimeListChapter)) {
 			const { requestURL, body } = buildMyAnimeListBody(true, this.manga, this.csrf, this.manga.status);
 			// no need to wait until mal is informed
-			browser.runtime.sendMessage({
+			await browser.runtime.sendMessage({
 				action: "fetch",
 				url: requestURL,
 				options: {
@@ -1426,7 +1428,7 @@ class MyMangaDex {
 			if (hiddenCount > 0) {
 				let navBar = document.querySelector(".nav.nav-tabs");
 				let button = document.createElement("li");
-				button.className = "nav-item";
+				button.className = "nav-item mmdNav";
 				let link = document.createElement("a");
 				this.appendTextWithIcon(link, "eye", ["Show Hidden (", hiddenCount, ")"].join(""));
 				link.className = "nav-link"; link.href = "#";

--- a/scripts/myMangaDex.js
+++ b/scripts/myMangaDex.js
@@ -1270,18 +1270,20 @@ class MyMangaDex {
 		this.manga.currentChapter = this.manga.currentChapter || { chapter: -1, volume: 0 };
 		if (markUnread) {
 			let updateLast = this.manga.lastMangaDexChapter == chapter;
+			if (updateLast) {
+				this.manga.currentChapter.chapter = 0;
+				this.manga.lastMangaDexChapter = 0;
+			}
 			this.manga.chapters = this.manga.chapters.filter(chap => {
 				// update to next smaller chapter
 				if (updateLast && chap < chapter) {
-					this.manga.currentChapter.chapter = chap;
-					this.manga.lastMangaDexChapter = chap;
 					updateLast = false;
 				}
 				return chap != chapter
 			});
 		} else {
 			this.insertChapter(chapter);
-			if (chapter > this.manga.lastMangaDexChapter) {
+			if (chapter > this.manga.lastMangaDexChapter || chapter > this.manga.lastMyAnimeListChapter) {
 				this.manga.currentChapter.chapter = chapter;
 				this.manga.lastMangaDexChapter = chapter;
 			}
@@ -1289,7 +1291,6 @@ class MyMangaDex {
 
 		if (this.manga.myAnimeListId && (!this.manga.lastMyAnimeListChapter || Math.floor(this.manga.lastMangaDexChapter) != this.manga.lastMyAnimeListChapter)) {
 			const { requestURL, body } = buildMyAnimeListBody(true, this.manga, this.csrf, this.manga.status);
-			// no need to wait until mal is informed
 			await browser.runtime.sendMessage({
 				action: "fetch",
 				url: requestURL,

--- a/scripts/myMangaDex.js
+++ b/scripts/myMangaDex.js
@@ -1367,8 +1367,8 @@ class MyMangaDex {
 						}
 						// if check for updates, has mal title and last checked more than 12 hours ago (12*60*60*1000ms)
 						if (checkUpdates && this.options.updateOnFollows && toUpdate.length < 7 &&
-							!titleInformations[group.titleId].getsUpdated && titleInformations[group.titleId].mal != 0 /*&&
-							(!titleInformations[group.titleId].lastMAL || (Date.now() - titleInformations[group.titleId].lastMAL) >= 43200000)*/) {
+							!titleInformations[group.titleId].getsUpdated && titleInformations[group.titleId].mal != 0 &&
+							(!titleInformations[group.titleId].lastMAL || (Date.now() - titleInformations[group.titleId].lastMAL) >= 43200000)) {
 							toUpdate.push({
 								myAnimeListId: titleInformations[group.titleId].mal,
 								mangaDexId: group.titleId,

--- a/scripts/myMangaDex.js
+++ b/scripts/myMangaDex.js
@@ -896,12 +896,12 @@ class MyMangaDex {
 			});
 
 			await this.updateManga(false, status, true);
-			if (this.informationsNode != undefined) {
-				this.insertMyAnimeListInformations();
-			}
 			this.notification(NOTIFY.SUCCESS, "Manga Updated", undefined, this.myAnimeListImage);
 			this.modalControl(false);
 			this.highlightChapters(); // Highlight last again
+			if (this.informationsNode != undefined) {
+				this.insertMyAnimeListInformations();
+			}
 		});
 		modalFooter.appendChild(modalSave);
 
@@ -1420,7 +1420,7 @@ class MyMangaDex {
 				for (var i = 0; i < toUpdate.length; i++) {
 					if (!this.loggedMyAnimeList) break;
 					let manga = toUpdate[i];
-					
+
 					let ret = await this.fetchMyAnimeList(manga);
 					if (ret.status >= 200 && ret.status < 400 && this.loggedMyAnimeList && manga.is_approved) {
 						manga.currentChapter = manga.currentChapter || {};

--- a/scripts/myMangaDex.js
+++ b/scripts/myMangaDex.js
@@ -1568,7 +1568,7 @@ class MyMangaDex {
          * Tooltips
          */
     // only add tooltips on first iteration
-		if (this.options.showTooltips && (!checkUpdates || !toUpdate.length)) {
+		if (this.options.showTooltips) {
 			if (!this.tooltipContainer && !(this.tooltipContainer = document.querySelector("#mmd-tooltip"))) {
 				this.tooltipContainer = document.createElement("div");
 				this.tooltipContainer.id = "mmd-tooltip";

--- a/scripts/myMangaDex.js
+++ b/scripts/myMangaDex.js
@@ -72,10 +72,10 @@ class MyMangaDex {
 		}
 
 		// clean up existing nodes
-		const oldDomNodes = document.querySelectorAll("body > .gn-wrapper, #mmd-tooltip, .nav-item.mmdNav");
-		oldDomNodes.forEach(node => node.remove());
-		const oldToolTips = document.querySelectorAll(".row[data-loaded=\"true\"]");
-		oldToolTips.forEach(node => node.removeAttribute("data-loaded"));
+		// const oldDomNodes = document.querySelectorAll("body > .gn-wrapper, #mmd-tooltip, .nav-item.mmdNav");
+		// oldDomNodes.forEach(node => node.remove());
+		// const oldToolTips = document.querySelectorAll(".row[data-loaded=\"true\"]");
+		// oldToolTips.forEach(node => node.removeAttribute("data-loaded"));
 
 		const eyes = document.querySelectorAll(".chapter-row .chapter_mark_read_button, .chapter-row .chapter_mark_unread_button");
 		eyes.forEach(eye => eye.addEventListener("click", this.handleEyeClick.bind(this, eye)));

--- a/scripts/myMangaDex.js
+++ b/scripts/myMangaDex.js
@@ -1553,7 +1553,7 @@ class MyMangaDex {
 		// Informations
 		await this.getTitleInfos();
 		await this.fetchMyAnimeList();
-		if (this.mangaDexStatus === undefined) {
+		if (this.mangaDexStatus === undefined && (this.options.updateMDList || this.options.updateOnlyInList)) {
 			await this.fetchTitleInfos();
 		}
 
@@ -1581,7 +1581,7 @@ class MyMangaDex {
 				this.insertMyAnimeListButton(document.querySelector(".reader-controls-actions.col-auto.row.no-gutters.p-1").lastElementChild);
 			}
 
-			if (this.mangaDexStatus === undefined) {
+			if (this.mangaDexStatus === undefined && (this.options.updateMDList || this.options.updateOnlyInList)) {
 				await this.fetchTitleInfos(false);
 			}
 		}

--- a/scripts/myMangaDex.js
+++ b/scripts/myMangaDex.js
@@ -1545,6 +1545,8 @@ class MyMangaDex {
 				this.tooltipContainer = document.createElement("div");
 				this.tooltipContainer.id = "mmd-tooltip";
 				document.body.appendChild(this.tooltipContainer);
+			} else {
+				this.clearDomNode(this.tooltipContainer);
 			}
 			for (let i = 0; i < lastChapter; i++) {
 				let group = groups[i];

--- a/scripts/myMangaDex.js
+++ b/scripts/myMangaDex.js
@@ -1277,6 +1277,10 @@ class MyMangaDex {
 		return [domain, "images/manga/", this.manga.mangaDexId, ".thumb.jpg"].join('');
 	}
 
+	timeout(ms) {
+		return new Promise(resolve => setTimeout(resolve, ms));
+	}
+
 	async handleEyeClick(eye, event) {
 		const markUnread = eye.classList.contains('chapter_mark_unread_button');
 		let dataNode = eye;
@@ -1416,7 +1420,7 @@ class MyMangaDex {
 				for (var i = 0; i < toUpdate.length; i++) {
 					if (!this.loggedMyAnimeList) break;
 					let manga = toUpdate[i];
-
+					
 					let ret = await this.fetchMyAnimeList(manga);
 					if (ret.status >= 200 && ret.status < 400 && this.loggedMyAnimeList && manga.is_approved) {
 						manga.currentChapter = manga.currentChapter || {};
@@ -1426,6 +1430,7 @@ class MyMangaDex {
 						}			
 						await updateLocalStorage(manga, this.options);
 					}
+					await this.timeout(1000);
 				}
 				this.chapterListPage(false);
 			})(toUpdate); // run in background (async)

--- a/scripts/myMangaDex.js
+++ b/scripts/myMangaDex.js
@@ -1283,7 +1283,6 @@ class MyMangaDex {
 				}
 				return chap != chapter
 			});
-			console.log(this.manga.chapters);
 		} else {
 			this.insertChapter(chapter);
 			if (chapter > this.manga.lastMangaDexChapter || chapter > this.manga.lastMyAnimeListChapter) {
@@ -1308,6 +1307,7 @@ class MyMangaDex {
 					}
 				}
 			});
+			this.manga.lastMAL = Date.now();
 		}
 
 		// no need to wait until it's saved
@@ -1551,6 +1551,14 @@ class MyMangaDex {
 						(titleInformations[group.titleId]) ? titleInformations[group.titleId].chapters : []
 					);
 				}
+			}
+		}
+
+
+		// set all toUpdate to false
+		if (!checkUpdates || !toUpdate.length) {
+			for (title in titleInformations) {
+				if (titleInformations[title].getsUpdated) titleInformations[title].getsUpdated = false;
 			}
 		}
 	}

--- a/scripts/myMangaDex.js
+++ b/scripts/myMangaDex.js
@@ -1294,6 +1294,8 @@ class MyMangaDex {
 			if (this.manga.myAnimeListId) await this.fetchMyAnimeList();
 		}
 		this.manga.currentChapter = this.manga.currentChapter || { chapter: -1, volume: 0 };
+		this.manga.lastMangaDexChapter = this.manga.lastMangaDexChapter || this.manga.currentChapter.chapter;
+		this.manga.chapters = this.manga.chapters || [];
 		if (markUnread) {
 			let updateLast = this.manga.lastMangaDexChapter == chapter;
 			if (updateLast) {
@@ -1318,7 +1320,7 @@ class MyMangaDex {
 		}
 
 		if (this.manga.myAnimeListId && (!this.manga.lastMyAnimeListChapter || Math.floor(this.manga.lastMangaDexChapter) != this.manga.lastMyAnimeListChapter)) {
-			const { requestURL, body } = buildMyAnimeListBody(true, this.manga, this.csrf, this.manga.status);
+			const { requestURL, body } = buildMyAnimeListBody(true, this.manga, this.csrf, this.manga.status || 1);
 			await browser.runtime.sendMessage({
 				action: "fetch",
 				url: requestURL,
@@ -1599,7 +1601,7 @@ class MyMangaDex {
 				if (titleInformations[title])
 					if (titleInformations[title].getsUpdated)
 						titleInformations[title].getsUpdated = false;
-					if (titleInformations[title].options)
+					if (titleInformations[title].options) // make sure to update tooltips (eye-click)
 						delete titleInformations[title].options;
 			}
 		}

--- a/scripts/myMangaDex.js
+++ b/scripts/myMangaDex.js
@@ -1444,25 +1444,30 @@ class MyMangaDex {
 
 			let navBar = document.querySelector(".nav.nav-tabs");
 			let button = document.querySelector(".mmdNav-hidden");
-			if (button) button.remove();
+			let show = false;
+			if (button) {
+				show = !!button.firstChild.dataset.show;
+				button.remove();
+			}
 
 			if (hiddenCount > 0) {
 				button = document.createElement("li");
 				button.className = "nav-item mmdNav mmdNav-hidden";
 				let link = document.createElement("a");
-				this.appendTextWithIcon(link, "eye", ["Show Hidden (", hiddenCount, ")"].join(""));
+				this.appendTextWithIcon(link, "eye", [!show ? "Show Hidden (" : "Hide Hidden (", hiddenCount, ")"].join(""));
+				if (show) link.dataset.show = true;
 				link.className = "nav-link"; link.href = "#";
 				link.addEventListener("click", event => {
 					event.preventDefault();
 					clearDomNode(link);
-					if (event.target.dataset.show == undefined) {
-						event.target.dataset.show = true;
+					if (!link.dataset.show) {
+						link.dataset.show = true;
 						this.appendTextWithIcon(link, "eye", ["Hide Hidden (", hiddenCount, ")"].join(""));
 						rows.forEach(node => {
 							node.classList.add("is-visible");
 						});
 					} else {
-						delete event.target.dataset.show;
+						delete link.dataset.show;
 						this.appendTextWithIcon(link, "eye", ["Show Hidden (", hiddenCount, ")"].join(""));
 						rows.forEach(node => {
 							node.classList.remove("is-visible");
@@ -1536,7 +1541,7 @@ class MyMangaDex {
          */
     // only add tooltips on first iteration
 		if (this.options.showTooltips && (!checkUpdates || !toUpdate.length)) {
-			if (!this.tooltipContainer) {
+			if (!this.tooltipContainer && !(this.tooltipContainer = document.querySelector("#mmd-tooltip"))) {
 				this.tooltipContainer = document.createElement("div");
 				this.tooltipContainer.id = "mmd-tooltip";
 				document.body.appendChild(this.tooltipContainer);

--- a/scripts/sharedFunctions.js
+++ b/scripts/sharedFunctions.js
@@ -158,29 +158,29 @@ async function loadOptions() {
 		if ((data.version != defaultOptions.version) ||
 			(data.version == defaultOptions.version && data.subVersion != defaultOptions.subVersion)) {
 			// Fix history wrong progress
-            /*let history = await storageGet("history");
-            if (history) {
-                Object.keys(history).forEach(md_id => {
-                    if (md_id == 'list') return;
-                    if (history[md_id]) {
-                        if (history[md_id].progress == null) {
-                            history[md_id].progress = {
-                                volume: 0,
-                                chapter: 0
-                            };
-                        } else if (typeof history[md_id].progress != 'object') {
-                            history[md_id].progress = {
-                                volume: 0,
-                                chapter: history[md_id].progress
-                            };
-                        }
-                    } else {
-                        history[md_id] = undefined;
-                    }
-                });
-            } else {
-                history = { list: [] };
-            }
+			/*let history = await storageGet("history");
+			if (history) {
+				Object.keys(history).forEach(md_id => {
+					if (md_id == 'list') return;
+					if (history[md_id]) {
+						if (history[md_id].progress == null) {
+							history[md_id].progress = {
+								volume: 0,
+								chapter: 0
+							};
+						} else if (typeof history[md_id].progress != 'object') {
+							history[md_id].progress = {
+								volume: 0,
+								chapter: history[md_id].progress
+							};
+						}
+					} else {
+						history[md_id] = undefined;
+					}
+				});
+			} else {
+				history = { list: [] };
+			}
 			await storageSet("history", history);*/
 			if (data.version == 2.3 && data.subVersion == 10) {
 				SimpleNotification.info({
@@ -208,12 +208,18 @@ async function updateLocalStorage(manga, options) {
 			manga.lastMangaDexChapter = manga.currentChapter.chapter;
 		}
 	}
-	await storageSet(manga.mangaDexId, {
+	nManga = {
 		mal: manga.myAnimeListId,
 		last: manga.lastMangaDexChapter,
-		chapters: manga.chapters,
-		lastTitle: manga.lastTitle
-	});
+		chapters: manga.chapters
+	};
+	if (manga.myAnimeListId == 0 || options.updateHistoryPage) {
+		nManga.lastTitle = manga.lastTitle; // only save time if needed
+	}
+	if (manga.myAnimeListId != 0 && options.updateOnFollows) {
+		nManga.lastMAL = manga.lastMAL; // only save time if needed
+	}
+	await storageSet(manga.mangaDexId, nManga);
 	// Show a notification for updated last opened if there is no MyAnimeList id
 	if (options.showNotifications && manga.myAnimeListId == 0 &&
 		manga.currentChapter && manga.currentChapter.chapter > manga.lastMangaDexChapter) {


### PR DESCRIPTION
On follows page (only follows, not all chapterList pages) fetch MAL information from at most 7 titles with a MAL ID that have a unread higher chapter and haven't been fetched for the last 12 hours (Closes #27)
On clicking the eye symbol on any page, the chapter is added/removed from the chapterlist. If adding and the chapter is higher, the chapter is set as highest and sent to MAL. If removing and is current chapter, set next lowest as current and send to MAL. (Closes #41)
Clean up old DOM nodes on start (e.g. after update)