### PR TITLE
Fix legacy detection

### DIFF
--- a/scripts/myMangaDex.js
+++ b/scripts/myMangaDex.js
@@ -1831,7 +1831,7 @@ class MyMangaDex {
 
 	singleChapterPage() {
 		this.manga.name = /scans\s*,\s+(.+)\s+mangadex/i.exec(document.querySelector("meta[name='keywords']").content)[1];
-		const legacyReader = !document.getElementById("content").classList.contains("reader");
+		const legacyReader = !document.querySelector('.reader-controls-container');
 		if (legacyReader) {
 			this.singleChapterPageLegacy();
 			return;


### PR DESCRIPTION
In newer FireFoxes on slower connections it appears that the extension loads before the reader, so the detection of the new reader via body class fails since that is added dynamically. Changing the detection to a element in the source fixed this (no more 'update to chapter 0')